### PR TITLE
2.0.1

### DIFF
--- a/js/appManager.js
+++ b/js/appManager.js
@@ -119,26 +119,26 @@ export const appManager = (() => {
           blockEl.addEventListener("click", function (e) {
             // Ignore clicks on action buttons and tag buttons
             if (e.target.closest(".action-button") || e.target.closest(".tag-button")) return;
-
+        
             const blockId = blockEl.getAttribute("data-id");
             const blocksArr = appManager.getBlocks(tab);
             const targetBlock = blocksArr.find(b => b.id === blockId);
             if (!targetBlock) return;
-
+        
             if (targetBlock.viewState === "expanded") {
-              // Retrieve the active view state from localStorage (defaulting to "condensed")
-              const activeState = localStorage.getItem("activeViewState") || "condensed";
+              // Retrieve the active view state for the current tab from localStorage (defaulting to "condensed")
+              const activeState = localStorage.getItem(`activeViewState_${tab}`) || "condensed";
               targetBlock.viewState = activeState;
             } else {
               // Otherwise, set it to expanded
               targetBlock.viewState = "expanded";
             }
-
+        
             localStorage.setItem(`userBlocks_${tab}`, JSON.stringify(blocksArr));
             appManager.renderBlocks(tab);
           });
         });
-              
+                      
         // Attach click event to the minimize buttons (present in expanded blocks)
         document.querySelectorAll(`#${sectionId} .minimize_button`).forEach(button => {
           button.addEventListener("click", function (e) {

--- a/js/circleToggle.js
+++ b/js/circleToggle.js
@@ -353,8 +353,9 @@ if (tab4ToggleCircles) {
             circle.classList.remove('unfilled');
         }
 
-        // Save the state on click
-        circle.addEventListener('click', () => {
+        // Save the state on click and log the event
+        circle.addEventListener('click', (e) => {
+            console.log(`circleToggle.js (Tab 4): Click event fired for circle with key "${key}".`);
             circle.classList.toggle('unfilled');
             const state = circle.classList.contains('unfilled');
             localStorage.setItem(key, state);

--- a/js/main.js
+++ b/js/main.js
@@ -472,20 +472,6 @@ if (savedViewState === "condensed") {
     document.getElementById("view_minimized_button")?.classList.add("active");
 }
 
-document.addEventListener('click', (event) => {
-    const toggleCircle = event.target.closest('.toggle-circle');
-    if (toggleCircle && (toggleCircle.closest('#tab4') || toggleCircle.closest('#tab8'))) {
-      toggleCircle.classList.toggle('unfilled');
-      const key = toggleCircle.getAttribute('data-storage-key');
-      if (key) {
-        localStorage.setItem(key, toggleCircle.classList.contains('unfilled'));
-        console.log(`Updated ${key} to ${toggleCircle.classList.contains('unfilled')}`);
-      } else {
-        console.warn('Toggle circle missing data-storage-key:', toggleCircle);
-      }
-    }
-});
-
 window.onload = async () => {
     console.log("🔄 Window Loaded - Initializing App");
 


### PR DESCRIPTION
Bug Fixes: Circles in tabs 4 and 8 are working again and when clicking an open block it now checks for the tab's active viewstate and returns the block to the correct viewstate