### PR TITLE
2.4.3

### DIFF
--- a/css/forms.css
+++ b/css/forms.css
@@ -166,6 +166,10 @@
     pointer-events: auto;
 }
 
+.text-toolbar button:hover {
+    background-color: #777;
+}
+
 .text-toolbar button.selected {
     background-color: #666;
     border-color: #888;
@@ -241,9 +245,9 @@
 
 /* Find & Replace Panel */
 .find-replace-panel {
-    background-color: #3a3a3a;
+    background-color: #444;
     border-bottom: 1px solid #555;
-    padding: 8px 12px;
+    padding: 12px 12px;
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -277,10 +281,11 @@
 
 .fr-btn {
     padding: 6px 10px;
-    font-size: 13px;
+    font-size: 14px;
     background-color: #555;
     color: #fff;
-    border: none;
+    border: 1px solid #555;
+    opacity: 0.5;
     border-radius: 6px;
     cursor: pointer;
     white-space: nowrap;
@@ -288,21 +293,17 @@
 }
 
 .fr-btn:hover {
-    background-color: #666;
-}
-
-.fr-close {
-    background-color: #ff6b6b;
+    background-color: #777;
 }
 
 .fr-close:hover {
     background-color: #ff8e8e;
+    opacity: 1;
 }
 
 .fr-feedback {
     font-size: 12px;
     color: #aaa;
-    min-height: 16px;
 }
 
 .fr-highlight {

--- a/css/forms.css
+++ b/css/forms.css
@@ -236,3 +236,82 @@
 .add-block-form.show, .cleardata-form.show, .edit-block-overlay.show {
     z-index: 1000;
 }
+
+
+
+/* Find & Replace Panel */
+.find-replace-panel {
+    background-color: #3a3a3a;
+    border-bottom: 1px solid #555;
+    padding: 8px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    position: sticky;
+    top: 0;
+    z-index: 5;
+}
+
+.find-replace-panel.hidden {
+    display: none;
+}
+
+.find-replace-row {
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+    align-items: center;
+}
+
+.find-replace-row input {
+    flex: 1;
+    padding: 6px 10px;
+    font-size: 14px;
+    background-color: #444;
+    color: #fff;
+    border: 1px solid #555;
+    border-radius: 6px;
+    box-sizing: border-box;
+    margin: 0;
+}
+
+.fr-btn {
+    padding: 6px 10px;
+    font-size: 13px;
+    background-color: #555;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background-color 0.2s;
+}
+
+.fr-btn:hover {
+    background-color: #666;
+}
+
+.fr-close {
+    background-color: #ff6b6b;
+}
+
+.fr-close:hover {
+    background-color: #ff8e8e;
+}
+
+.fr-feedback {
+    font-size: 12px;
+    color: #aaa;
+    min-height: 16px;
+}
+
+.fr-highlight {
+    background-color: rgba(255, 200, 0, 0.35);
+    border-radius: 2px;
+}
+
+.fr-highlight-active {
+    background-color: rgba(255, 200, 0, 0.75);
+    border-radius: 2px;
+    outline: 1px solid rgba(255, 180, 0, 0.9);
+}

--- a/index.html
+++ b/index.html
@@ -976,7 +976,7 @@
                 <div id="block_text_overlay" class="auto-resize" contenteditable="true" data-placeholder="Enter block text here..." rows="1"></div>
                 <input type="text" id="tags_input_overlay" placeholder="Enter custom tags here..."  />
             </div>
-            <div class="overlay-tags" id="dynamic_overlay_tags"></div>
+            <div class="overlay-tags" id="add_block_overlay_tags"></div>
             <div class="overlay-controls">
                 <button id="save-block-button" class="button green-button">Save Block</button>
                 <button id="clear_block_button" class="button orange-button">Clear</button>

--- a/index.html
+++ b/index.html
@@ -1066,7 +1066,20 @@
         <button id="cancel_remove_button" class="button red-button">No</button>
       </div>
     </div>
-  </div>
+</div>
+
+<!-- Overlay for Deleting Action Rows -->
+<div class="cleardata-overlay remove-action-overlay">
+    <div class="cleardata-form">
+        <h2>Delete Action</h2>
+        <p>Are you sure you want to delete this action?</p>
+        <div class="overlay-controls">
+            <button id="confirm_remove_action_button" class="button green-button">Yes</button>
+            <button id="cancel_remove_action_button" class="button red-button">No</button>
+        </div>
+    </div>
+</div>
+
   
     <script type="module" src="js/tagConfig.js"></script>
     <script type="module" src="js/appManager.js"></script>

--- a/js/appManager.js
+++ b/js/appManager.js
@@ -88,7 +88,7 @@ export const actionButtonHandlers = (() => {
         }
 
         // Initialize overlay predefined tags
-        overlayHandler.initializeOverlayTagHandlers("dynamic_overlay_tags");
+        overlayHandler.initializeOverlayTagHandlers("add_block_overlay_tags");
 
         // Open overlay and focus the title input after a short delay
         elements.addBlockOverlay.classList.add("show");

--- a/js/appManager.js
+++ b/js/appManager.js
@@ -191,7 +191,10 @@ export const appManager = (() => {
     const selectedTags = tagHandler.getSelectedTags(activeTab);
   
     // Get all predefined tags from tagConfig.js
-    const allPredefined = Object.values(categoryTags).flatMap(cat => cat.tags);
+    const allPredefined = Object.entries(categoryTags)
+        .filter(([_, data]) => data.tabs.includes(activeTab))
+        .flatMap(([_, data]) => data.tags);
+
     // Determine user-defined tags (those not in the predefined list)
     const usedUserTags = usedTags
       .filter(tag => !allPredefined.includes(tag))
@@ -498,7 +501,7 @@ export const appManager = (() => {
         }
       }
       blocks.forEach(block => {
-        resultsSection.insertAdjacentHTML("beforeend", blockTemplate(block));
+          resultsSection.insertAdjacentHTML("beforeend", blockTemplate(block, tab));
       });
       console.log(`✅ UI updated: Blocks re-rendered for ${tab}`);
         

--- a/js/appManager.js
+++ b/js/appManager.js
@@ -267,6 +267,8 @@ export const appManager = (() => {
   ToggleFilters.forEach(button => {
     button.addEventListener("click", () => {
       const container = button.closest(".filter-and-results");
+      const tabContent = button.closest(".tab-content");
+      const tabId = tabContent ? tabContent.id : null;
       const selectors = [
         ".filter-section",
         ".filter-section-wrapper",
@@ -279,13 +281,18 @@ export const appManager = (() => {
         .forEach(el => el.classList.toggle("hidden"));
 
       const filterSection = container.querySelector(".filter-section");
-      if (filterSection.classList.contains("hidden")) {
+      const isHidden = filterSection.classList.contains("hidden");
+
+      if (isHidden) {
         button.innerHTML = '<img src="./images/Filter_Open_Icon.svg" alt="Filter icon">';
       } else {
         button.innerHTML = '<img src="./images/Filter_Hide_Icon.svg" alt="Arrow left icon">';
-      }  
+      }
+
+      if (tabId) localStorage.setItem(`filterVisible_${tabId}`, (!isHidden).toString());
     });
   });
+
 
 /* ==================================================================*/
 /* ============================= BLOCKS =============================*/

--- a/js/appManager.js
+++ b/js/appManager.js
@@ -112,12 +112,12 @@ export const actionButtonHandlers = (() => {
 
     // Confirm Clear Data - Purge entire localStorage and reload
     if (elements.confirmClearButton && elements.clearDataOverlay) {
-      elements.confirmClearButton.addEventListener("click", () => {
+      elements.confirmClearButton.onclick = () => {
         console.log("✅ Confirm Clear Data button clicked");
         localStorage.clear();
         alert("All data has been cleared.");
         location.reload();
-      });
+    };
     } else {
       console.error("❌ Error: Confirm Clear button not found.");
     }

--- a/js/blockActionsHandler.js
+++ b/js/blockActionsHandler.js
@@ -58,7 +58,8 @@ export const saveEditHandler = () => {
     tagsInput = tagsInput.filter(tag => !currentBlockTags.includes(tag));
 
     // Combine: include any remaining typed tags, selected tag buttons, and the block’s current tags
-    const combinedTagsLowercase = [...new Set([...currentBlockTags, ...tagsInput, ...selectedPredefinedTags])];
+    const combinedTagsLowercase = [...new Set([...tagsInput, ...selectedPredefinedTags])];
+
 
     // Re-capitalize each tag (first letter uppercase, rest lowercase) for display purposes
     const allTags = combinedTagsLowercase.map(tag => tag.charAt(0).toUpperCase() + tag.slice(1));

--- a/js/blockTemplate.js
+++ b/js/blockTemplate.js
@@ -2,17 +2,21 @@ import { tagHandler } from './tagHandler.js';
 import { categoryTags } from './tagConfig.js';
 import { toggleBlockUse } from './circleToggle.js';
 
-export const blockTemplate = (block) => {
-    // Ensure a default view state
+export const blockTemplate = (block, tab = "tab1") => {
     const viewState = block.viewState || 'expanded';
     const selectedTags = tagHandler.getSelectedTags();
 
-    // Build tags HTML
+    const tabPredefinedTags = Object.entries(categoryTags)
+        .filter(([_, data]) => data.tabs.includes(tab))
+        .flatMap(([_, data]) => data.tags);
+
     const predefinedTagsByCategory = Object.fromEntries(
-        Object.entries(categoryTags).map(([category, data]) => [
-            category,
-            Array.isArray(data.tags) ? data.tags.filter(tag => block.tags.includes(tag)) : []
-        ])
+        Object.entries(categoryTags)
+            .filter(([_, data]) => data.tabs.includes(tab))
+            .map(([category, data]) => [
+                category,
+                Array.isArray(data.tags) ? data.tags.filter(tag => block.tags.includes(tag)) : []
+            ])
     );
 
     const predefinedTagsHTML = Object.entries(predefinedTagsByCategory)
@@ -25,7 +29,7 @@ export const blockTemplate = (block) => {
         )
         .join("");
 
-    const predefinedTagList = Object.values(categoryTags).flatMap(data => data.tags);
+    const predefinedTagList = tabPredefinedTags;
     const userTags = block.tags
         .filter(tag => !predefinedTagList.includes(tag))
         .map(tag => tag.charAt(0).toUpperCase() + tag.slice(1).toLowerCase());
@@ -44,14 +48,14 @@ export const blockTemplate = (block) => {
     ` : "";
 
     // Process block text formatting
-        let bodyHTML = block.text || "";
-        bodyHTML = bodyHTML
-          .replace(/<div[^>]*>/gi, '')      // strip any opening <div>
-          .replace(/^(&nbsp;|\s)+/gi, '')   // strip any leading &nbsp; or whitespace
-          .replace(/<\/div>/gi, '<br>')     // convert closing </div> to <br>
-          .replace(/<p[^>]*>/gi, '')        // strip any opening <p>
-          .replace(/<\/p>/gi, '<br>')       // convert closing </p> to <br>
-          .trim();                          // remove leading/trailing whitespace
+    let bodyHTML = block.text || "";
+    bodyHTML = bodyHTML
+        .replace(/<div[^>]*>/gi, '')
+        .replace(/^(&nbsp;|\s)+/gi, '')
+        .replace(/<\/div>/gi, '<br>')
+        .replace(/<p[^>]*>/gi, '')
+        .replace(/<\/p>/gi, '<br>')
+        .trim();
 
     // Determine if there is body content
     const hasBody = bodyHTML.trim() !== "";
@@ -81,7 +85,6 @@ export const blockTemplate = (block) => {
                 </div>
             ` : "" }
         `;
-
     } else if (viewState === 'condensed') {
         const usesHTML = block.uses
             ? block.uses.map((state, idx) => `<span class=\"circle ${state ? 'unfilled' : ''}\" onclick=\"toggleBlockUse('${block.id}', ${idx}, event, this)\"></span>`).join("")

--- a/js/editButtonHandler.js
+++ b/js/editButtonHandler.js
@@ -272,6 +272,7 @@ if (saveActionsButton) {
       if (newGrid) {
         // Remove all drag handle elements from each row.
         newGrid.querySelectorAll('.drag-handle').forEach(handle => handle.remove());
+        newGrid.querySelectorAll('.remove-action-button').forEach(btn => btn.remove());
         
         // Filter out completely empty rows.
         let rows = Array.from(newGrid.querySelectorAll('.action-row')).filter(row => !isactionRowCompletelyEmpty(row));
@@ -297,7 +298,13 @@ if (saveActionsButton) {
         });
 
         // Build new HTML content from the re-indexed rows.
-        const newHTML = rows.map(row => row.outerHTML).join('');
+        const newHTML = rows.map(row => {
+          // ensure full content is saved not the condensed first-line version
+          row.querySelectorAll('.action-name, .action-label, .action-description').forEach(field => {
+            if (field.dataset.fullContent) field.innerHTML = field.dataset.fullContent;
+          });
+          return row.outerHTML;
+        }).join('');
         
         // Update the actions grid in the source tab (currentTab) with the new content.
         const targetGrid = document.querySelector('#' + currentTab + ' .actions-grid');
@@ -437,6 +444,7 @@ function createEmptyactionRow(nextIndex, tabPrefix) {
 
   // Create and append the drag-handle first.
   const dragHandle = document.createElement('span');
+  dragHandle.classList.add('drag-handle');
   dragHandle.setAttribute('tabindex', '0');
   dragHandle.setAttribute('draggable', 'true');
   dragHandle.innerHTML = "&#9776;";
@@ -477,25 +485,36 @@ function createEmptyactionRow(nextIndex, tabPrefix) {
   // Listen for input events so that a new empty row is appended as needed.
   row.addEventListener('input', () => {
     ensureExtraEmptyactionRow();
+    // add remove button once row has content
+    if (!isactionRowCompletelyEmpty(row) && !row.querySelector('.remove-action-button')) {
+      const removeButton = document.createElement('button');
+      removeButton.classList.add('action-button', 'red-button', 'remove-action-button');
+      removeButton.textContent = '×';
+      row.appendChild(removeButton);
+    }
   });
-
   return row;
 }
-
 
 // Helper: Drag to reorder rows.
 function addDragHandlesToOverlay() {
   const grid = document.querySelector('.actions-edit-overlay .actions-edit-container .actions-grid');
   if (!grid) return;
   grid.querySelectorAll('.action-row').forEach(row => {
-      if (!row.querySelector('.drag-handle')) {
-          const dragHandle = document.createElement('span');
-          dragHandle.classList.add('drag-handle');
-          dragHandle.setAttribute('tabindex', '0');
-          dragHandle.setAttribute('draggable', 'true');
-          dragHandle.innerHTML = "&#9776;";
-          row.insertBefore(dragHandle, row.firstChild);
-      }
+    if (!row.querySelector('.drag-handle')) {
+        const dragHandle = document.createElement('span');
+        dragHandle.classList.add('drag-handle');
+        dragHandle.setAttribute('tabindex', '0');
+        dragHandle.setAttribute('draggable', 'true');
+        dragHandle.innerHTML = "&#9776;";
+        row.insertBefore(dragHandle, row.firstChild);
+    }
+    if (!row.querySelector('.remove-action-button') && !isactionRowCompletelyEmpty(row)) {
+        const removeButton = document.createElement('button');
+        removeButton.classList.add('action-button', 'red-button', 'remove-action-button');
+        removeButton.textContent = '×';
+        row.appendChild(removeButton);
+    }
   });
 }
 
@@ -505,8 +524,10 @@ function initializeActionRowToggles() {
   // Set the initial state (condensed) for all existing .action-row elements.
   const actionRows = document.querySelectorAll('.action-row');
   actionRows.forEach(row => {
-    row.classList.add('condensed');
-    row.classList.remove('expanded');
+    if (!row.dataset.viewState) {
+      row.classList.add('condensed');
+      row.classList.remove('expanded');
+    }
 
     // Find the toggle button within the row
     const toggleButton = row.querySelector('button');
@@ -532,17 +553,50 @@ function initializeActionRowToggles() {
         console.warn("Toggle button clicked, but no parent .action-row found.");
         return;
       }
-      // Toggle between expanded and condensed states and update button symbol accordingly.
       if (row.classList.contains('expanded')) {
         row.classList.remove('expanded');
         row.classList.add('condensed');
+        row.dataset.viewState = 'condensed';
         toggleButton.textContent = "+";
-        console.log(`Action row containing button "${toggleButton.textContent}" toggled to condensed.`);
+        row.querySelectorAll('.action-name, .action-label, .action-description').forEach(field => {
+          if (!field.dataset.fullContent) field.dataset.fullContent = field.innerHTML;
+          field.innerHTML = field.innerHTML.split('<br>')[0];
+        });
       } else {
         row.classList.remove('condensed');
         row.classList.add('expanded');
+        row.dataset.viewState = 'expanded';
         toggleButton.textContent = "-";
-        console.log(`Action row containing button "${toggleButton.textContent}" toggled to expanded.`);
+        row.querySelectorAll('.action-name, .action-label, .action-description').forEach(field => {
+          if (field.dataset.fullContent) field.innerHTML = field.dataset.fullContent;
+        });
+      }
+      // save state after either toggle
+      const actionsGrid = row.closest('.actions-grid');
+      const tabContent = row.closest('.tab-content');
+      if (actionsGrid && tabContent) {
+        const rows = Array.from(actionsGrid.querySelectorAll('.action-row'));
+        const html = rows.map(r => {
+          const clone = r.cloneNode(true);
+          clone.querySelectorAll('.action-name, .action-label, .action-description').forEach(field => {
+              if (field.dataset.fullContent) field.innerHTML = field.dataset.fullContent;
+          });
+          // strip text-wrap-mode: nowrap from any inner elements
+          clone.querySelectorAll('[style]').forEach(el => {
+            const style = el.getAttribute('style');
+            const cleaned = style.replace(/text-wrap-mode\s*:\s*nowrap;?/gi, '');
+            if (cleaned.trim()) {
+              el.setAttribute('style', cleaned);
+            } else {
+              el.removeAttribute('style');
+            }
+          });
+          const state = clone.dataset.viewState || 'condensed';
+          clone.classList.remove('condensed', 'expanded');
+          clone.classList.add(state);
+          return clone.outerHTML;
+        }).join('');
+        localStorage.setItem(tabContent.id + '_actions_grid', html);
       }
     }
   });
@@ -706,17 +760,46 @@ function ensureExtraEmptyactionRow() {
       grid.appendChild(newRow);
   }
 }
-  
-  // Call on initialization to add listeners to any existing rows and ensure an extra empty row.
-  function initializeDynamicactionRows() {
-    const grid = document.querySelector('.actions-edit-overlay .actions-edit-container .actions-grid');
-    if (!grid) return;
-    const rows = grid.querySelectorAll('.action-row');
-    rows.forEach(row => {
-      row.addEventListener('input', () => {
-        ensureExtraEmptyactionRow();
-      });
+
+let pendingRemoveRow = null;
+
+document.addEventListener('click', e => {
+    const removeBtn = e.target.closest('.remove-action-button');
+    if (!removeBtn) return;
+    pendingRemoveRow = removeBtn.closest('.action-row');
+    const overlay = document.querySelector('.remove-action-overlay');
+    if (overlay) overlay.classList.add('show');
+});
+
+const confirmRemoveAction = document.getElementById('confirm_remove_action_button');
+const cancelRemoveAction = document.getElementById('cancel_remove_action_button');
+
+if (confirmRemoveAction) {
+    confirmRemoveAction.onclick = () => {
+        if (pendingRemoveRow) {
+            pendingRemoveRow.remove();
+            pendingRemoveRow = null;
+        }
+        document.querySelector('.remove-action-overlay').classList.remove('show');
+    };
+}
+
+if (cancelRemoveAction) {
+    cancelRemoveAction.onclick = () => {
+        pendingRemoveRow = null;
+        document.querySelector('.remove-action-overlay').classList.remove('show');
+    };
+}
+
+// Call on initialization to add listeners to any existing rows and ensure an extra empty row.
+function initializeDynamicactionRows() {
+  const grid = document.querySelector('.actions-edit-overlay .actions-edit-container .actions-grid');
+  if (!grid) return;
+  const rows = grid.querySelectorAll('.action-row');
+  rows.forEach(row => {
+    row.addEventListener('input', () => {
+      ensureExtraEmptyactionRow();
     });
-    ensureExtraEmptyactionRow();
-  }
-  
+  });
+  ensureExtraEmptyactionRow();
+}

--- a/js/main.js
+++ b/js/main.js
@@ -581,7 +581,6 @@ const keyboardShortcutsHandler = (() => {
 
             if (addBlockOverlay?.classList.contains("show")) {
                 if (event.key === "Enter" && saveBlockButton) {
-                    // if inside a list, drop a new item instead of saving
                     const inUL = document.queryCommandState('insertUnorderedList');
                     const inOL = document.queryCommandState('insertOrderedList');
                     if (!(inUL || inOL)) {
@@ -589,7 +588,8 @@ const keyboardShortcutsHandler = (() => {
                         saveBlockButton.click();
                     }
                 } else if (event.key === "Escape" && cancelAddBlockButton) {
-                    cancelAddBlockButton.click();
+                    const openFrPanel = addBlockOverlay.querySelector('.find-replace-panel:not(.hidden)');
+                    if (!openFrPanel) cancelAddBlockButton.click();
                 }
             }
 
@@ -610,9 +610,11 @@ const keyboardShortcutsHandler = (() => {
                         saveEditButton.click();
                     }
                 } else if (event.key === "Escape" && cancelEditButton) {
-                    cancelEditButton.click();
+                    const openFrPanel = editBlockOverlay.querySelector('.find-replace-panel:not(.hidden)');
+                    if (!openFrPanel) cancelEditButton.click();
                 }
             }
+
 
             if (spellSlotEditOverlay?.classList.contains("show")) {
                 if (event.key === "Enter" && saveSpellSlotButton) {

--- a/js/main.js
+++ b/js/main.js
@@ -130,6 +130,29 @@ document.addEventListener("DOMContentLoaded", () => {
         console.log("Tab order restored:", savedOrder);
     }
 
+    // Restore filter section visibility for each tab
+    [1, 2, 3, 4, 5, 6, 7, 8].forEach(num => {
+    const tabId = `tab${num}`;
+    const saved = localStorage.getItem(`filterVisible_${tabId}`);
+    if (saved === "false") {
+        const tab = document.getElementById(tabId);
+        if (!tab) return;
+        const button = tab.querySelector(".toggle-filter-button");
+        const container = tab.querySelector(".filter-and-results");
+        if (!button || !container) return;
+
+        const selectors = [
+            ".filter-section",
+            ".filter-section-wrapper",
+            ".filter-section-overlay-top",
+            ".filter-section-overlay-bottom"
+        ].join(", ");
+
+        container.querySelectorAll(selectors).forEach(el => el.classList.add("hidden"));
+        button.innerHTML = '<img src="./images/Filter_Open_Icon.svg" alt="Filter icon">';
+        }
+    });
+
     const tabButtons = document.querySelectorAll(".tab-button");
     tabButtons.forEach(button => {
         button.addEventListener("dragstart", () => {

--- a/js/main.js
+++ b/js/main.js
@@ -265,6 +265,25 @@ document.addEventListener("DOMContentLoaded", () => {
             // Lock the fields so they aren't editable on the main screen.
             actionsGrid.querySelectorAll('.action-name, .action-label, .action-description')
               .forEach(field => field.contentEditable = "false");
+            // restore condensed/expanded display state
+            actionsGrid.querySelectorAll('.action-row').forEach(row => {
+              console.log('viewState:', row.dataset.viewState, '| classes:', row.className);
+              const btn = row.querySelector('button');
+              if (row.dataset.viewState === 'expanded') {
+                row.classList.remove('condensed');
+                row.classList.add('expanded');
+                if (btn) btn.textContent = "-";
+              } else {
+                row.classList.remove('expanded');
+                row.classList.add('condensed');
+                if (btn) btn.textContent = "+";
+                // collapse to first line
+                row.querySelectorAll('.action-name, .action-label, .action-description').forEach(field => {
+                  if (!field.dataset.fullContent) field.dataset.fullContent = field.innerHTML;
+                  field.innerHTML = field.innerHTML.split('<br>')[0];
+                });
+              }
+            });
           } else {
             console.warn("actions grid element not found in " + tabId);
           }
@@ -617,6 +636,19 @@ const keyboardShortcutsHandler = (() => {
                     confirmRemoveButton.click();
                 } else if (event.key === "Escape" && cancelRemoveButton) {
                     cancelRemoveButton.click();
+                }
+            }
+
+            const removeActionOverlay = document.querySelector('.remove-action-overlay');
+            const confirmRemoveActionButton = document.getElementById('confirm_remove_action_button');
+            const cancelRemoveActionButton = document.getElementById('cancel_remove_action_button');
+
+            if (removeActionOverlay?.classList.contains('show')) {
+                if (event.key === 'Enter' && confirmRemoveActionButton) {
+                    event.preventDefault();
+                    confirmRemoveActionButton.click();
+                } else if (event.key === 'Escape' && cancelRemoveActionButton) {
+                    cancelRemoveActionButton.click();
                 }
             }
 

--- a/js/overlayHandler.js
+++ b/js/overlayHandler.js
@@ -312,7 +312,9 @@ export const overlayHandler = (() => {
         const exceptionTabs = ["tab3", "tab6", "tab7"];
     
         // Get predefined and user-defined tags
-        const predefinedTagList = Object.values(categoryTags).flatMap(cat => cat.tags);
+        const predefinedTagList = Object.entries(categoryTags)
+            .filter(([_, data]) => data.tabs.includes(activeTab))
+            .flatMap(([_, data]) => data.tags);
         const userDefinedTags = [
             ...new Set(
                 appManager.getBlocks(activeTab)

--- a/js/overlayHandler.js
+++ b/js/overlayHandler.js
@@ -449,7 +449,7 @@ export const overlayHandler = (() => {
 function addFormatToolbar() {
     const configs = [
       { formSel: '.add-block-form', textareaId: 'block_text_overlay' },
-      { formSel: '.edit-block-form',   textareaId: 'block_text_edit_overlay' }
+      { formSel: '.edit-block-form', textareaId: 'block_text_edit_overlay' }
     ];
   
     configs.forEach(({ formSel, textareaId }) => {
@@ -462,13 +462,13 @@ function addFormatToolbar() {
       const toolbar = document.createElement('div');
       toolbar.className = 'text-toolbar';
       toolbar.innerHTML = `
-        <button type="button" data-action="bold"><i class="fas fa-bold"></i></button>
-        <button type="button" data-action="italic"><i class="fas fa-italic"></i></button>
-        <button type="button" data-action="underline"><i class="fas fa-underline"></i></button>
-        <button type="button" data-action="link"><i class="fas fa-link"></i></button>
-        <button type="button" data-action="insertUnorderedList"><i class="fas fa-list-ul"></i></button>
-        <button type="button" data-action="insertOrderedList"><i class="fas fa-list-ol"></i></button>
-        <button type="button" data-action="increaseFont"><i class="fas fa-arrow-up"></i></button>
+        <button type="button" data-action="bold" data-tooltip="Bold"><i class="fas fa-bold"></i></button>
+        <button type="button" data-action="italic" data-tooltip="Italic"><i class="fas fa-italic"></i></button>
+        <button type="button" data-action="underline" data-tooltip="Underline"><i class="fas fa-underline"></i></button>
+        <button type="button" data-action="link" data-tooltip="Link"><i class="fas fa-link"></i></button>
+        <button type="button" data-action="insertUnorderedList" data-tooltip="Unordered List"><i class="fas fa-list-ul"></i></button>
+        <button type="button" data-action="insertOrderedList" data-tooltip="Ordered List"><i class="fas fa-list-ol"></i></button>
+        <button type="button" data-action="increaseFont" data-tooltip="Increase Font"><i class="fas fa-arrow-up"></i></button>
         <select id="font-size-select">
             <option value="3">16px</option>
             <option value="4">18px</option>
@@ -476,10 +476,12 @@ function addFormatToolbar() {
             <option value="6">32px</option>
             <option value="7">48px</option>
         </select>
-        <button type="button" data-action="decreaseFont"><i class="fas fa-arrow-down"></i></button>
-        <button type="button" data-action="uppercase">A↑</button>
-        <button type="button" data-action="sentencecase">Aa</button>
-        <button type="button" data-action="lowercase">a↓</button>
+        <button type="button" data-action="decreaseFont" data-tooltip="Decrease Font"><i class="fas fa-arrow-down"></i></button>
+        <button type="button" data-action="uppercase" data-tooltip="Uppercase">A↑</button>
+        <button type="button" data-action="sentencecase" data-tooltip="Sentence case">Aa</button>
+        <button type="button" data-action="lowercase" data-tooltip="Lowercase">a↓</button>
+        <button type="button" data-action="removeStyling" data-tooltip="Remove styling">✕</button>
+        <button type="button" data-action="findReplace" data-tooltip="Find and Replace">A→B</button>
       `;
   
       const wrapper = document.createElement('div');
@@ -487,7 +489,231 @@ function addFormatToolbar() {
       editor.parentNode.replaceChild(wrapper, editor);
       wrapper.appendChild(toolbar);
       wrapper.appendChild(editor);
-  
+
+      // ── Find & Replace Panel — created BEFORE buttons forEach ──
+      const frPanel = document.createElement('div');
+      frPanel.className = 'find-replace-panel hidden';
+      frPanel.innerHTML = `
+        <div class="find-replace-row">
+            <input type="text" class="fr-find" placeholder="Find..." />
+            <input type="text" class="fr-replace" placeholder="Replace..." />
+        </div>
+        <div class="find-replace-row">
+            <button type="button" class="fr-btn fr-find-next">Find Next</button>
+            <button type="button" class="fr-btn fr-replace-one">Replace One</button>
+            <button type="button" class="fr-btn fr-replace-all">Replace All</button>
+            <button type="button" class="fr-btn fr-close">✕</button>
+        </div>
+        <div class="fr-feedback"></div>
+      `;
+      wrapper.insertBefore(frPanel, editor);
+
+      let frMatches = [];
+      let frIndex = -1;
+
+      const frFind = frPanel.querySelector('.fr-find');
+      const frReplace = frPanel.querySelector('.fr-replace');
+      const frFeedback = frPanel.querySelector('.fr-feedback');
+
+      // remove all highlights entirely
+      const clearFrHighlights = () => {
+        editor.querySelectorAll('span.fr-highlight, span.fr-highlight-active').forEach(span => {
+          span.replaceWith(...span.childNodes);
+        });
+        editor.normalize();
+      };
+
+      // walk text nodes to find matches — does NOT touch the DOM
+      const findTextMatches = () => {
+        const results = [];
+        const query = frFind.value;
+        if (!query) return results;
+        const regex = new RegExp(query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi');
+        const walk = (node) => {
+          if (node.nodeType === Node.TEXT_NODE) {
+            const text = node.nodeValue;
+            let match;
+            while ((match = regex.exec(text)) !== null) {
+              results.push({ node, index: match.index, length: match[0].length });
+            }
+          } else {
+            // skip highlight spans so we don't double-match
+            if (node.nodeType === Node.ELEMENT_NODE &&
+                (node.classList.contains('fr-highlight') || node.classList.contains('fr-highlight-active'))) {
+              results.push({ node: node.firstChild, index: 0, length: node.textContent.length });
+              return;
+            }
+            node.childNodes.forEach(walk);
+          }
+        };
+        walk(editor);
+        return results;
+      };
+
+      // highlight all matches subtly, with optional active index highlighted more prominently
+      const highlightAll = (activeIdx = -1) => {
+        clearFrHighlights();
+        if (frMatches.length === 0) return;
+        // wrap each match in a span — go in reverse to preserve text node indices
+        [...frMatches].reverse().forEach(({ node, index, length }, reversedI) => {
+          const actualI = frMatches.length - 1 - reversedI;
+          if (!node || !node.parentNode) return;
+          const range = document.createRange();
+          range.setStart(node, index);
+          range.setEnd(node, index + length);
+          const span = document.createElement('span');
+          span.className = actualI === activeIdx ? 'fr-highlight-active' : 'fr-highlight';
+          range.surroundContents(span);
+        });
+        // scroll active match into view
+        if (activeIdx >= 0) {
+          const active = editor.querySelector('span.fr-highlight-active');
+          if (active) {
+            active.scrollIntoView({ block: 'nearest' });
+          }
+        }
+    };
+
+      // rebuild match list from current DOM state
+      const buildMatches = () => {
+        clearFrHighlights();
+        frMatches = findTextMatches();
+        frIndex = -1;
+        frFeedback.textContent = '';
+        if (frMatches.length === 0) {
+          if (frFind.value) frFeedback.textContent = 'No matches found';
+        } else {
+          frFeedback.textContent = `${frMatches.length} match${frMatches.length !== 1 ? 'es' : ''} found`;
+          highlightAll();
+        }
+      };
+
+      frFind.addEventListener('input', () => {
+        buildMatches();
+      });
+
+      frPanel.querySelector('.fr-find-next').addEventListener('mousedown', e => {
+        e.preventDefault();
+        // rebuild from clean DOM before advancing
+        clearFrHighlights();
+        frMatches = findTextMatches();
+        if (frMatches.length === 0) {
+          frFeedback.textContent = 'No matches found';
+          return;
+        }
+        frIndex = (frIndex + 1) % frMatches.length;
+        highlightAll(frIndex);
+        if (frIndex === frMatches.length - 1) {
+          frFeedback.textContent = `Match ${frIndex + 1} of ${frMatches.length} — no more matches after this`;
+        } else {
+          frFeedback.textContent = `Match ${frIndex + 1} of ${frMatches.length}`;
+        }
+      });
+
+      frPanel.querySelector('.fr-replace-one').addEventListener('mousedown', e => {
+        e.preventDefault();
+        if (frIndex < 0 || frMatches.length === 0) {
+          frFeedback.textContent = 'Use Find Next to select a match first';
+          return;
+        }
+        const active = editor.querySelector('span.fr-highlight-active');
+        if (!active) {
+          frFeedback.textContent = 'Use Find Next to select a match first';
+          return;
+        }
+
+        // replace the active span's text with the replacement value
+        // keep a reference to where we are so we can highlight the replacement
+        const replacedIndex = frIndex;
+        const replaceText = frReplace.value;
+
+        // swap content of active span to replacement text and change to fr-highlight
+        // so it stays visible after rebuild
+        active.textContent = replaceText;
+        active.className = 'fr-highlight-active';
+
+        // clear all other highlights, leaving only the replaced one
+        editor.querySelectorAll('span.fr-highlight').forEach(span => {
+          span.replaceWith(...span.childNodes);
+        });
+        editor.normalize();
+
+        // find fresh matches (excludes the replaced word since it's now different)
+        frMatches = findTextMatches();
+
+        // frIndex should point to the next match after the replaced one
+        // since one match was removed, the next match is now at replacedIndex
+        // (or wrap to 0 if we were at the last one)
+        if (frMatches.length === 0) {
+          frIndex = -1;
+          frFeedback.textContent = 'No more matches';
+          // clear the replacement highlight too since there's nothing left to find
+          editor.querySelectorAll('span.fr-highlight-active').forEach(span => {
+            span.replaceWith(...span.childNodes);
+          });
+          editor.normalize();
+        } else {
+          // set frIndex to one before where we'll next click Find Next
+          frIndex = replacedIndex - 1;
+          if (frIndex < -1) frIndex = frMatches.length - 1;
+          frFeedback.textContent = `${frMatches.length} match${frMatches.length !== 1 ? 'es' : ''} remaining — use Find Next to continue`;
+          // highlight all remaining matches subtly using highlightAll
+          // but only clear fr-highlight spans, leaving the fr-highlight-active replaced word intact
+          editor.querySelectorAll('span.fr-highlight').forEach(span => {
+            span.replaceWith(...span.childNodes);
+          });
+          editor.normalize();
+          frMatches = findTextMatches();
+          [...frMatches].reverse().forEach(({ node, index, length }) => {
+            if (!node || !node.parentNode) return;
+            const range = document.createRange();
+            range.setStart(node, index);
+            range.setEnd(node, index + length);
+            const span = document.createElement('span');
+            span.className = 'fr-highlight';
+            range.surroundContents(span);
+          });
+        }
+    });
+
+      frPanel.querySelector('.fr-replace-all').addEventListener('mousedown', e => {
+        e.preventDefault();
+        clearFrHighlights();
+        frMatches = findTextMatches();
+        if (frMatches.length === 0) {
+          frFeedback.textContent = 'No matches found';
+          return;
+        }
+        const count = frMatches.length;
+        const replaceText = frReplace.value;
+        // replace from last to first to preserve indices, wrap in highlight span
+        [...frMatches].reverse().forEach(({ node, index, length }) => {
+          if (!node || !node.parentNode) return;
+          const range = document.createRange();
+          range.setStart(node, index);
+          range.setEnd(node, index + length);
+          const span = document.createElement('span');
+          span.className = 'fr-highlight';
+          range.surroundContents(span);
+          span.textContent = replaceText;
+        });
+        editor.normalize();
+        frMatches = [];
+        frIndex = -1;
+        frFeedback.textContent = `${count} replacement${count !== 1 ? 's' : ''} made`;
+      });
+
+      frPanel.querySelector('.fr-close').addEventListener('mousedown', e => {
+        e.preventDefault();
+        clearFrHighlights();
+        frPanel.classList.add('hidden');
+        frMatches = [];
+        frIndex = -1;
+        frFeedback.textContent = '';
+        frFind.value = '';
+        frReplace.value = '';
+      });
+
       const buttons = toolbar.querySelectorAll('button');
       const sizeSelect = toolbar.querySelector('#font-size-select');
   
@@ -514,10 +740,39 @@ function addFormatToolbar() {
         }
       }
   
-      // Wire up all buttons including spinner
+      // tooltip logic
+      let activeTooltip = null;
       buttons.forEach(btn => {
+        const tooltipText = btn.dataset.tooltip;
+        if (tooltipText) {
+          btn.addEventListener('mouseenter', () => {
+            clearTimeout(btn._tooltipTimer);
+            btn._tooltipTimer = setTimeout(() => {
+              const tip = document.createElement('div');
+              tip.classList.add('text-tooltip');
+              tip.textContent = tooltipText;
+              document.body.appendChild(tip);
+              const rect = btn.getBoundingClientRect();
+              tip.style.left = `${rect.left}px`;
+              tip.style.top = `${rect.bottom + 5}px`;
+              activeTooltip = tip;
+            }, 750);
+          });
+          btn.addEventListener('mouseleave', () => {
+            clearTimeout(btn._tooltipTimer);
+            if (activeTooltip) {
+              activeTooltip.remove();
+              activeTooltip = null;
+            }
+          });
+        }
+
         btn.addEventListener('mousedown', e => {
           e.preventDefault();
+          if (activeTooltip) {
+            activeTooltip.remove();
+            activeTooltip = null;
+          }
           const action = btn.dataset.action;
           if (action === 'link') {
             const url = prompt('Enter URL');
@@ -534,18 +789,124 @@ function addFormatToolbar() {
               sizeSelect.selectedIndex = idx - 1;
               sizeSelect.dispatchEvent(new Event('change'));
             }
+          } else if (action === 'removeStyling') {
+            const sel = window.getSelection();
+            if (!sel.rangeCount) return;
+            const range = sel.getRangeAt(0);
+            const selectedText = range.toString();
+            if (!selectedText) return;
+
+            const frag = range.cloneContents();
+            const tempDiv = document.createElement('div');
+            tempDiv.appendChild(frag);
+
+            tempDiv.querySelectorAll('br').forEach(br => br.replaceWith('\n'));
+            tempDiv.querySelectorAll('p, div, li').forEach(el => {
+              el.insertAdjacentText('afterend', '\n');
+              el.replaceWith(el.textContent);
+            });
+            tempDiv.querySelectorAll('ul, ol').forEach(el => el.replaceWith(el.textContent));
+            tempDiv.querySelectorAll('*').forEach(el => el.replaceWith(el.textContent));
+
+            const newFrag = document.createDocumentFragment();
+            const lines = tempDiv.textContent.split('\n');
+            lines.forEach((line, i) => {
+              newFrag.appendChild(document.createTextNode(line));
+              if (i < lines.length - 1) newFrag.appendChild(document.createElement('br'));
+            });
+
+            range.deleteContents();
+            range.insertNode(newFrag);
+          } else if (action === 'findReplace') {
+            frPanel.classList.toggle('hidden');
+            if (!frPanel.classList.contains('hidden')) {
+              frFind.focus();
+            } else {
+              clearFrHighlights();
+              frMatches = [];
+              frIndex = -1;
+              frFeedback.textContent = '';
+            }
           } else if (['uppercase','sentencecase','lowercase'].includes(action)) {
             // fallback span-transform if needed
-            // transformSelection logic here
           } else {
             document.execCommand(action, false, null);
           }
           updateToolbarState();
         });
       });
-  
+
       editor.addEventListener('keyup', updateToolbarState);
       editor.addEventListener('mouseup', updateToolbarState);
+
+      editor.addEventListener('keydown', e => {
+        if (e.key === 'Escape' && !frPanel.classList.contains('hidden')) {
+          e.stopPropagation();
+          clearFrHighlights();
+          frPanel.classList.add('hidden');
+          frMatches = [];
+          frIndex = -1;
+          frFeedback.textContent = '';
+        }
+      });
+
+      frPanel.addEventListener('keydown', e => {
+        if (e.key === 'Escape') {
+          e.stopPropagation();
+          clearFrHighlights();
+          frPanel.classList.add('hidden');
+          frMatches = [];
+          frIndex = -1;
+          frFeedback.textContent = '';
+          frFind.value = '';
+          frReplace.value = '';
+        }
+      });
+
+      editor.addEventListener('paste', e => {
+        e.preventDefault();
+        const html = e.clipboardData.getData('text/html');
+        const text = e.clipboardData.getData('text/plain');
+
+        let cleaned = '';
+        if (html) {
+          const tempDiv = document.createElement('div');
+          tempDiv.innerHTML = html;
+
+          tempDiv.querySelectorAll('*').forEach(el => {
+            el.removeAttribute('style');
+            el.removeAttribute('color');
+            el.removeAttribute('face');
+            el.removeAttribute('size');
+            el.removeAttribute('bgcolor');
+            el.removeAttribute('background');
+            el.removeAttribute('class');
+          });
+
+          tempDiv.querySelectorAll('span').forEach(span => {
+            span.replaceWith(...span.childNodes);
+          });
+
+          tempDiv.querySelectorAll('font').forEach(font => {
+            font.replaceWith(...font.childNodes);
+          });
+
+          tempDiv.querySelectorAll('a').forEach(a => {
+            a.replaceWith(...a.childNodes);
+          });
+
+          cleaned = tempDiv.innerHTML;
+        } else {
+          cleaned = text
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/\n/g, '<br>');
+        }
+
+        document.execCommand('insertHTML', false, cleaned);
+        updateToolbarState();
+      });
     });
   }
     

--- a/js/overlayHandler.js
+++ b/js/overlayHandler.js
@@ -497,8 +497,6 @@ function addFormatToolbar() {
         <div class="find-replace-row">
             <input type="text" class="fr-find" placeholder="Find..." />
             <input type="text" class="fr-replace" placeholder="Replace..." />
-        </div>
-        <div class="find-replace-row">
             <button type="button" class="fr-btn fr-find-next">Find Next</button>
             <button type="button" class="fr-btn fr-replace-one">Replace One</button>
             <button type="button" class="fr-btn fr-replace-all">Replace All</button>
@@ -514,6 +512,7 @@ function addFormatToolbar() {
       const frFind = frPanel.querySelector('.fr-find');
       const frReplace = frPanel.querySelector('.fr-replace');
       const frFeedback = frPanel.querySelector('.fr-feedback');
+      frFeedback.style.display = 'none';
 
       // remove all highlights entirely
       const clearFrHighlights = () => {
@@ -589,10 +588,20 @@ function addFormatToolbar() {
       };
 
       frFind.addEventListener('input', () => {
+        if (!frFind.value) {
+          clearFrHighlights();
+          frMatches = [];
+          frIndex = -1;
+          frFeedback.textContent = '';
+          frFeedback.style.display = 'none';
+          return;
+        }
+        frFeedback.style.display = '';
         buildMatches();
       });
 
       frPanel.querySelector('.fr-find-next').addEventListener('mousedown', e => {
+        if (e.button !== 0) return;
         e.preventDefault();
         // rebuild from clean DOM before advancing
         clearFrHighlights();
@@ -603,6 +612,7 @@ function addFormatToolbar() {
         }
         frIndex = (frIndex + 1) % frMatches.length;
         highlightAll(frIndex);
+        frFeedback.style.display = '';
         if (frIndex === frMatches.length - 1) {
           frFeedback.textContent = `Match ${frIndex + 1} of ${frMatches.length} — no more matches after this`;
         } else {
@@ -677,6 +687,7 @@ function addFormatToolbar() {
     });
 
       frPanel.querySelector('.fr-replace-all').addEventListener('mousedown', e => {
+        if (e.button !== 0) return;
         e.preventDefault();
         clearFrHighlights();
         frMatches = findTextMatches();
@@ -704,12 +715,14 @@ function addFormatToolbar() {
       });
 
       frPanel.querySelector('.fr-close').addEventListener('mousedown', e => {
+        if (e.button !== 0) return;
         e.preventDefault();
         clearFrHighlights();
         frPanel.classList.add('hidden');
         frMatches = [];
         frIndex = -1;
         frFeedback.textContent = '';
+        frFeedback.style.display = 'none';
         frFind.value = '';
         frReplace.value = '';
       });
@@ -768,6 +781,7 @@ function addFormatToolbar() {
         }
 
         btn.addEventListener('mousedown', e => {
+          if (e.button !== 0) return;
           e.preventDefault();
           if (activeTooltip) {
             activeTooltip.remove();

--- a/js/overlayHandler.js
+++ b/js/overlayHandler.js
@@ -131,7 +131,7 @@ export const handleSaveBlock = () => {
         // 4. For Tab 3: filter out any typed tags that already exist in the dynamic overlay.
         const exceptionTabs = ["tab3", "tab6", "tab7"];
         if (exceptionTabs.includes(activeTab)) {
-            const dynamicTagsContainer = document.getElementById("dynamic_overlay_tags");
+            const dynamicTagsContainer = document.getElementById("add_block_overlay_tags");
             let existingUserDefinedTags = [];
             if (dynamicTagsContainer) {
                 existingUserDefinedTags = Array.from(
@@ -325,7 +325,7 @@ export const overlayHandler = (() => {
         .map(tag => tag.charAt(0).toUpperCase() + tag.slice(1).toLowerCase())
         .sort((a, b) => a.localeCompare(b));
                     
-        if (containerId === "dynamic_overlay_tags") {
+        if (containerId === "dynamic_overlay_tags" || containerId === "add_block_overlay_tags") {
             if (exceptionTabs.includes(activeTab)) {
                 let html = "";
                 // Add user-defined tags, if any:


### PR DESCRIPTION
Fixed not being able to remove tags from blocks.
Fixed the add block overlay not showing the predefined tags.
Fixed the clear all data duplicate event listener.
Added functionality to rember filter sections visibility.
Fixed incorrectly expanding action rows in Tab 8 and added a new way
 to remove action rows with a delete button in the edit actions overview.
Fixed a bug causing custom tags matching predefined tags in other tab
s to not appear correctly in the edit overlay and share styling with the predefined tag
Added a hover state for the text toolbar buttons and stoped right click activating these buttons.
Added tooltips on hover to all button in the text toolbar.
Added a remove text styling button to the text toolbar.
Added a find and replace button to the text toolbar.
Pasting text into blocks now appears in the default styling instead of styling copied with the text.