### PR TITLE
3.2.0

### DIFF
--- a/css/tags.css
+++ b/css/tags.css
@@ -268,3 +268,29 @@
     gap: 10px;
     width: 100%;
 }
+
+
+/* ==================================================================*/
+/* ======================== BLOCK PROPERTIES ========================*/
+/* ==================================================================*/
+
+.block-properties {
+    display: flex;
+    flex-wrap: wrap;
+    margin-top: 10px;
+    column-gap: 7px;
+    row-gap: 8px;
+}
+
+.block-property {
+    padding: 6px 8px;
+    color: #fff;
+    background-color: rgba(255, 255, 255, 0.1);
+    border: none;
+    border-radius: 7px;
+    font-size: 16px;
+    letter-spacing: 0.3px;
+    white-space: pre-wrap;
+    display: inline-flex;
+    align-items: center;
+}

--- a/index.html
+++ b/index.html
@@ -895,7 +895,8 @@
             <div class="block-type-tags" id="character_type_tags_add"></div>
             <div class="add_and_edit_inputs">
                 <input type="text" id="title_input_overlay" placeholder="Enter block title here..." />
-                <div id="uses_field_overlay" class="uses-field"></div>   
+                <div id="uses_field_overlay" class="uses-field"></div>
+                <input type="text" id="properties_input_overlay" placeholder="Enter properties here (comma separated)..." />
                 <div id="block_text_overlay" class="auto-resize" contenteditable="true" data-placeholder="Enter block text here..." rows="1"></div>
                 <input type="text" id="tags_input_overlay" placeholder="Enter custom tags here..."  />
             </div>
@@ -916,7 +917,8 @@
             <div class="block-type-tags" id="character_type_tags_edit"></div>
             <div class="add_and_edit_inputs">
                 <input type="text" id="title_input_edit_overlay" placeholder="Edit title block" />
-                <div id="uses_field_edit_overlay" class="uses-field"></div>        
+                <div id="uses_field_edit_overlay" class="uses-field"></div>
+                <input type="text" id="properties_input_edit_overlay" placeholder="Enter properties here (comma separated)..." />
                 <div id="block_text_edit_overlay" class="auto-resize" contenteditable="true" data-placeholder="Enter block text here..." rows="1"></div>
                 <input type="text" id="tags_input_edit_overlay" placeholder="Edit tags (comma separated)" />
             </div>

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
             </button>
 
             <button id="dice-menu-button" class="hero-button dice-menu-button clear-button">
-                <img src="images/Dice_button_v2.svg" alt="D20" />
+                <img src="images/Dice_Button_v2.svg" alt="D20" />
             </button>
     
             <button id="Menu_button" class="hero-button Menu-button">

--- a/js/appManager.js
+++ b/js/appManager.js
@@ -693,11 +693,15 @@ const renderBlocks = (tab = getActiveTab(), filteredBlocks = null) => {
             return false;
         }
     } else {
-        const predefinedTagsSet = new Set(Object.values(categoryTags).flatMap(cat => cat.tags));
-        const formattedTags = tags.map(tag => 
-            predefinedTagsSet.has(tag) ? tag : tag.charAt(0).toUpperCase() + tag.slice(1).toLowerCase()
+        const predefinedTagsMap = new Map(
+            Object.values(categoryTags).flatMap(cat => cat.tags).map(tag => [tag.toLowerCase(), tag])
         );
-    
+        const formattedTags = tags.map(tag => {
+            const predefined = predefinedTagsMap.get(tag.toLowerCase());
+            if (predefined) return predefined;
+            return tag.charAt(0).toUpperCase() + tag.slice(1).toLowerCase();
+        });
+            
         const newBlock = {
           id: crypto.randomUUID(),
           title: blockTitle,

--- a/js/appManager.js
+++ b/js/appManager.js
@@ -497,8 +497,9 @@ const renderBlocks = (tab = getActiveTab(), filteredBlocks = null) => {
           if (searchInput && searchInput.value.trim() !== "") {
             const query = searchInput.value.trim().toLowerCase();
             filteredBlocks = filteredBlocks.filter(block =>
-              block.title.toLowerCase().includes(query) ||
-              stripHTML(block.text).toLowerCase().includes(query)
+                block.title.toLowerCase().includes(query) ||
+                stripHTML(block.text).toLowerCase().includes(query) ||
+                (block.properties || []).some(p => p.toLowerCase().includes(query))
             );
           }
           
@@ -652,7 +653,7 @@ const renderBlocks = (tab = getActiveTab(), filteredBlocks = null) => {
 /* ======================== DATA MANAGEMENT ========================*/
 /* =================================================================*/
 
-  const saveBlock = (tab, blockTitle, text, tags, uses, blockType = null, blockId = null, timestamp = null) => {
+  const saveBlock = (tab, blockTitle, text, tags, uses, properties = [], blockType = null, blockId = null, timestamp = null) => {
     console.log(`📥 Attempting to save block in ${tab}:`, { blockTitle, text, tags, uses, blockId, timestamp });
     
     if (
@@ -681,6 +682,7 @@ const renderBlocks = (tab = getActiveTab(), filteredBlocks = null) => {
               text,
               tags,
               uses,
+              properties,
               blockType,
               timestamp: userBlocks[blockIndex].timestamp || Date.now()
             };
@@ -702,6 +704,7 @@ const renderBlocks = (tab = getActiveTab(), filteredBlocks = null) => {
           text: text,
           tags: formattedTags,
           uses,
+          properties,
           blockType: blockType || null,
           timestamp: timestamp || Date.now(),
           viewState: "expanded"

--- a/js/blockActionsHandler.js
+++ b/js/blockActionsHandler.js
@@ -84,13 +84,17 @@ export const saveEditHandler = () => {
 
     const usesState = JSON.parse(localStorage.getItem("uses_field_edit_overlay_state") || "[]");
 
+    const propertiesInput = document.getElementById("properties_input_edit_overlay").value
+        .split(",")
+        .map(p => p.trim())
+        .filter(p => p.length > 0);
+
     const blockType = tabBTConfig
         ? Array.from(document.querySelectorAll('#character_type_tags_edit .tag-button.selected')).map(b => b.dataset.tag)
         : null;
 
     appManager.saveBlock(
-        activeTab, titleInput, textInput, allTags,
-        usesState, blockType, blockId, blocks[blockIndex].timestamp
+        activeTab, titleInput, textInput, allTags, usesState, propertiesInput, blockType, blockId, blocks[blockIndex].timestamp
     );
     console.log(`✅ Block updated in ${activeTab} with tags:`, allTags);
 
@@ -117,8 +121,9 @@ export const saveEditHandler = () => {
             if (searchQuery) {
                 filteredBlocks = filteredBlocks.filter(block => {
                     return block.title.toLowerCase().includes(searchQuery) ||
-                           stripHTML(block.text).toLowerCase().includes(searchQuery) ||
-                           block.tags.some(tag => tag.toLowerCase().includes(searchQuery));
+                        stripHTML(block.text).toLowerCase().includes(searchQuery) ||
+                        block.tags.some(tag => tag.toLowerCase().includes(searchQuery)) ||
+                        (block.properties || []).some(p => p.toLowerCase().includes(searchQuery));
                 });
             }
 
@@ -193,7 +198,7 @@ export const blockActionsHandler = (() => {
         if (target.classList.contains("duplicate-button")) {
             console.log("📄 Duplicating block:", blockId);
             const blockTags = Array.isArray(block.tags) ? [...block.tags] : [];
-            appManager.saveBlock(activeTab, `${block.title} (Copy)`, block.text, blockTags, block.uses || [], block.blockType || null);
+            appManager.saveBlock(activeTab, `${block.title} (Copy)`, block.text, blockTags, block.uses || [], block.properties || [], block.blockType || null);
             reapplySearchAndFilters();
 
         } else if (target.classList.contains("edit-button")) {
@@ -225,7 +230,9 @@ export const blockActionsHandler = (() => {
             } else {
                 document.getElementById("tags_input_edit_overlay").value = userDefinedTags.join(", ");
             }
-                                
+
+            document.getElementById("properties_input_edit_overlay").value = (block.properties || []).join(", ");
+
             const editOverlay = document.querySelector(".edit-block-overlay");
             if (editOverlay) {
                 editOverlay.dataset.activeTab = activeTab;
@@ -304,7 +311,8 @@ export const blockActionsHandler = (() => {
             filteredBlocks = filteredBlocks.filter(block =>
                 block.title.toLowerCase().includes(searchQuery) ||
                 stripHTML(block.text).toLowerCase().includes(searchQuery) ||
-                block.tags.some(tag => tag.toLowerCase().includes(searchQuery))
+                block.tags.some(tag => tag.toLowerCase().includes(searchQuery)) ||
+                (block.properties || []).some(p => p.toLowerCase().includes(searchQuery))
             );
         }
     

--- a/js/blockActionsHandler.js
+++ b/js/blockActionsHandler.js
@@ -58,7 +58,14 @@ export const saveEditHandler = () => {
     tagsInput = tagsInput.filter(tag => !currentBlockTags.includes(tag));
 
     const combinedTagsLowercase = [...new Set([...tagsInput, ...selectedPredefinedTags])];
-    const allTags = combinedTagsLowercase.map(tag => tag.charAt(0).toUpperCase() + tag.slice(1));
+    const predefinedTagsMap = new Map(
+        Object.values(categoryTags).flatMap(cat => cat.tags).map(t => [t.toLowerCase(), t])
+    );
+    const allTags = combinedTagsLowercase.map(tag => {
+        const predefined = predefinedTagsMap.get(tag);
+        if (predefined) return predefined;
+        return tag.charAt(0).toUpperCase() + tag.slice(1).toLowerCase();
+    });
 
     if (
         !titleInput ||

--- a/js/blockTemplate.js
+++ b/js/blockTemplate.js
@@ -38,6 +38,12 @@ export const blockTemplate = (block, tab = "tab4") => {
         return `<span class=\"tag-button tag-user ${isSelected}\" data-tag=\"${tag}\">${tag}</span>`;
     }).join("");
 
+    const propertiesHTML = (viewState === 'expanded' && block.properties && block.properties.length > 0)
+    ? `<div class="block-properties">${block.properties.map(p =>
+        `<span class="block-property">${p}</span>`
+      ).join("")}</div>`
+    : "";
+
     // Only render block-tags if there are any tags
     const blockTypes = Array.isArray(block.blockType) ? block.blockType : (block.blockType ? [block.blockType] : []);
     const blockTypeHTML = blockTypes.map(bt =>
@@ -87,6 +93,7 @@ export const blockTemplate = (block, tab = "tab4") => {
             </div>
             </div>
             ${tagSectionsHTML}
+            ${propertiesHTML}
             ${ hasBody ? `
                 <div class="block-body">
                     <span>${bodyHTML}</span>

--- a/js/main.js
+++ b/js/main.js
@@ -99,7 +99,7 @@ function setDicePanelState(open) {
   dicePanel.classList.toggle("open", open);
   diceMenuButton.classList.toggle("active", open);
   if (diceMenuImg) {
-    diceMenuImg.src = open ? "images/Dice_button_v2_Green.svg" : "images/Dice_button_v2.svg";
+    diceMenuImg.src = open ? "images/Dice_Button_v2_Green.svg" : "images/Dice_Button_v2.svg";
   }
   localStorage.setItem("dicePanelOpen", open);
 }

--- a/js/main.js
+++ b/js/main.js
@@ -36,14 +36,15 @@ function filterAndRender(tabNumber) {
   
     // 3) by search
     const query = document
-      .getElementById(`search_input_${tabNumber}`)
-      ?.value.trim().toLowerCase() || "";
-    if (query) {
-      blocks = blocks.filter(b =>
-        b.title.toLowerCase().includes(query) ||
-        stripHTML(b.text).toLowerCase().includes(query)
-      );
-    }
+        .getElementById(`search_input_${tabNumber}`)
+        ?.value.trim().toLowerCase() || "";
+            if (query) {
+                blocks = blocks.filter(b =>
+                    b.title.toLowerCase().includes(query) ||
+                    stripHTML(b.text).toLowerCase().includes(query) ||
+                    (b.properties || []).some(p => p.toLowerCase().includes(query))
+                );
+            }
   
     appManager.renderBlocks(activeTab, blocks);
 }
@@ -494,9 +495,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
             const resultsSection = document.getElementById(`results_section_${tabNumber}`);
             resultsSection.querySelectorAll('.block-title').forEach(el => {
-                el.innerHTML = highlightInText(el.textContent, query);
+                el.innerHTML = highlightInText(el.innerHTML, query);
             });
             resultsSection.querySelectorAll('.block-body').forEach(el => {
+                el.innerHTML = highlightInHTML(el.innerHTML, query);
+            });
+            resultsSection.querySelectorAll('.block-property').forEach(el => {
                 el.innerHTML = highlightInHTML(el.innerHTML, query);
             });
         });

--- a/js/overlayHandler.js
+++ b/js/overlayHandler.js
@@ -170,7 +170,12 @@ export const handleSaveBlock = () => {
             ? Array.from(document.querySelectorAll('#character_type_tags_add .tag-button.selected')).map(b => b.dataset.tag)
             : null;
 
-        const success = appManager.saveBlock(activeTab, titleInput, textInput, allTags, usesState, blockType);
+        const propertiesInput = document.getElementById("properties_input_overlay").value
+            .split(",")
+            .map(p => p.trim())
+            .filter(p => p.length > 0);
+
+        const success = appManager.saveBlock(activeTab, titleInput, textInput, allTags, usesState, propertiesInput, blockType);
 
         if (success) {
             console.log("✅ Block saved successfully with tags:", allTags);
@@ -184,6 +189,7 @@ export const handleSaveBlock = () => {
             textElement.innerHTML = "";
             textElement.dispatchEvent(new Event('input'));
             document.getElementById("tags_input_overlay").value = "";
+            document.getElementById("properties_input_overlay").value = "";
             document.querySelectorAll(".add-block-overlay .tag-button.selected")
                 .forEach(tag => tag.classList.remove("selected"));
             addBlockOverlay.classList.remove("show");
@@ -238,10 +244,12 @@ export const overlayHandler = (() => {
             const titleInput = document.getElementById("title_input_overlay");
             const textInput  = document.getElementById("block_text_overlay");
             const tagsInput  = document.getElementById("tags_input_overlay");
+            const propertiesInput = document.getElementById("properties_input_overlay");
     
             titleInput.value = "";
             textInput.value  = "";
             tagsInput.value  = "";
+            propertiesInput.value = "";
     
             document.querySelectorAll(".add-block-overlay .tag-button.selected").forEach(tag => {
                 tag.classList.remove("selected");
@@ -269,10 +277,12 @@ export const overlayHandler = (() => {
             const titleInput = document.getElementById("title_input_edit_overlay");
             const textInput  = document.getElementById("block_text_edit_overlay").innerHTML.trim();
             const tagsInput  = document.getElementById("tags_input_edit_overlay");
+            const propertiesInput = document.getElementById("properties_input_edit_overlay");
     
             titleInput.value = "";
             textInput.value  = "";
             tagsInput.value  = "";
+            propertiesInput.value = "";
     
             console.log("Edit overlay fields cleared.");
         });

--- a/js/overlayHandler.js
+++ b/js/overlayHandler.js
@@ -162,7 +162,14 @@ export const handleSaveBlock = () => {
         }
 
         const combinedTagsLowercase = [...new Set([...tagsInput, ...selectedPredefinedTags])];
-        const allTags = combinedTagsLowercase.map(tag => tag.charAt(0).toUpperCase() + tag.slice(1));
+        const predefinedTagsMap = new Map(
+            Object.values(categoryTags).flatMap(cat => cat.tags).map(t => [t.toLowerCase(), t])
+        );
+        const allTags = combinedTagsLowercase.map(tag => {
+            const predefined = predefinedTagsMap.get(tag);
+            if (predefined) return predefined;
+            return tag.charAt(0).toUpperCase() + tag.slice(1).toLowerCase();
+        });
 
         const usesState = JSON.parse(localStorage.getItem("uses_field_overlay_state") || "[]");
 

--- a/js/overlayHandler.js
+++ b/js/overlayHandler.js
@@ -406,6 +406,22 @@ export const overlayHandler = (() => {
             }
 
             tagsContainer.innerHTML = html;
+            // Inject chips into collapsed groups that have selected tags
+            tagsContainer.querySelectorAll('.tag-accordion-group:not(.open)').forEach(group => {
+                const pill = group.querySelector('.tag-accordion-pill');
+                const body = group.querySelector('.tag-accordion-body');
+                if (!pill || !body) return;
+                const tagClass = [...group.classList].find(c => c !== 'tag-accordion-group') || '';
+                body.querySelectorAll('.tag-button.selected').forEach(btn => {
+                    const chip = document.createElement('button');
+                    chip.classList.add('tag-accordion-chip');
+                    if (tagClass) chip.classList.add(tagClass);
+                    chip.dataset.tag = btn.dataset.tag;
+                    chip.textContent = btn.dataset.tag;
+                    pill.appendChild(chip);
+                });
+            });
+
         }
     
         tagsContainer.addEventListener("click", (event) => {

--- a/js/tagHandler.js
+++ b/js/tagHandler.js
@@ -95,7 +95,8 @@ export const tagHandler = (() => {
             if (searchQuery.length > 0) {
                 filteredBlocks = filteredBlocks.filter(block =>
                     block.title.toLowerCase().includes(searchQuery) ||
-                    stripHTML(block.text).toLowerCase().includes(searchQuery)
+                    stripHTML(block.text).toLowerCase().includes(searchQuery) ||
+                    (block.properties || []).some(p => p.toLowerCase().includes(searchQuery))
                 );
             }
                       


### PR DESCRIPTION
- Updated code reference from Dice_button to Dice_Button to reflect actual filename
- Added the functionality to add "Properties" to blocks to pull out key information from block text and create more compact and easily digestible block information hierarchies
- Fixed a bug causing predefined tags with specifically capitalised letters to incorrectly save as user-defined tags in sentence case
- Added code to ensure selected predefined tags are shown inside their tag-groups correctly upon opening the edit block overlay