### PR TITLE
3.4.1

### DIFF
--- a/css/CharacterSheet.css
+++ b/css/CharacterSheet.css
@@ -21,6 +21,11 @@
     min-width: 820px;
 }
 
+.character-sheet-stats .editable:focus {
+    outline: 2px solid var(--gray-600);
+    border-radius: 6px;
+}
+
 .cs-panel {
     padding: 10px;
     color: var(--gray-900);
@@ -94,9 +99,17 @@
     display: flex;
     flex-direction: row;
     justify-content: center;
+    align-items: center;
     align-content: center;
     margin: 0px 10px 0px 10px;
+    gap: 10px;
 }
+
+.current-stat-display .stat-value {
+    margin-left: 0;
+    margin-right: 0;
+}
+
 
 .stat-label {
     margin-bottom: 3px;
@@ -116,7 +129,6 @@
     font-size: 40px;
     font-weight: bold;
     min-width: 10px;
-    width: auto;
     text-align: center;
 }
 

--- a/css/base-layout.css
+++ b/css/base-layout.css
@@ -562,6 +562,12 @@ body:not(.landscape-mode) #char-sheet-panel .tab-content {
     gap: 10px;
 }
 
+.block.expanded {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
 .block.expanded .block-header {
     align-items: stretch;
 }
@@ -670,9 +676,7 @@ body:not(.landscape-mode) #char-sheet-panel .tab-content {
 .block-tags {
     display: flex;
     flex-wrap: wrap;
-    margin-top: 15px;
-    margin-bottom: 15px;
-    column-gap: 7px;
+    column-gap: 6px;
     row-gap: 8px;
 }
 
@@ -681,9 +685,8 @@ body:not(.landscape-mode) #char-sheet-panel .tab-content {
     flex-direction: column;
     width: 100%;
     padding: 0px;
-    margin-top: 6px;
     font-size: 16px;
-    line-height: 1.6;
+    line-height: 2;
     color: var(--gray-800);
     font-weight: 400;
     letter-spacing: 0.01em;

--- a/css/buttons.css
+++ b/css/buttons.css
@@ -267,7 +267,7 @@
     font-size: 0.9em;
     font-family: inherit;
     cursor: pointer;
-    line-height: inherit;
+    line-height: 1.5;
     vertical-align: baseline;
     transition: background-color 0.2s, color 0.2s;
 }

--- a/css/diceRoller.css
+++ b/css/diceRoller.css
@@ -182,7 +182,7 @@
   transition: transform 0.3s;
 }
 
-.selected-die:hover { transform: scale(1.05); }
+.selected-die:hover { background-color: color-mix(in srgb, var(--charges-color) 25%, transparent); }
 
 .selected-die-wrapper {
   position: relative;

--- a/css/tags.css
+++ b/css/tags.css
@@ -41,7 +41,12 @@
     align-items: center;
 }
 
-.tag-button:hover { transform: scale(1.05); }
+.block-tags .tag-button {
+    border-radius: 20px;
+    padding: 4px 14px;
+    height: auto;
+    font-size: 16px;
+}
 
 /* Per-category border + text colour */
 .tag-characterType  { border-color: var(--characterType-color);  color: var(--characterType-color); }
@@ -265,8 +270,7 @@
 .block-properties {
     display: flex;
     flex-wrap: wrap;
-    margin-top: 10px;
-    column-gap: 7px;
+    column-gap: 6px;
     row-gap: 8px;
 }
 

--- a/index.html
+++ b/index.html
@@ -131,8 +131,11 @@
                             <div class="stat-panel-box">
                                 <span class="stat-label">Hit Die</span>
                                 <span class="stat-value editable" contenteditable="true" data-storage-key="tab4_hit_die">1d10</span>
-                                <span class="stat-value editable" contenteditable="true" data-storage-key="tab4_hit_die_ratio">6 / 8</span>
-                            </div>
+                                <div class="current-stat-display" style="display: flex; gap: 10px;">
+                                    <span class="stat-value editable" contenteditable="true" data-storage-key="tab4_hit_die_current">00</span>
+                                    <span class="stat-value" style="font-weight:100; opacity: 0.5;">/</span>
+                                    <span class="stat-value" data-storage-key="tab4_hit_die_max"></span>
+                                </div>                            </div>
                         </div>
                         <div class="cs-panel stat-panel-row">
                             <div class="stat-panel-box">
@@ -407,7 +410,11 @@
                             <div class="stat-panel-box">
                                 <span class="stat-label">Hit Die</span>
                                 <span class="stat-value editable" contenteditable="true" data-storage-key="tab8_hit_die">00</span>
-                                <span class="stat-value editable" contenteditable="true" data-storage-key="tab8_hit_die_ratio">0</span>
+                                <div class="current-stat-display" style="display: flex; gap: 10px;">
+                                    <span class="stat-value editable" contenteditable="true" data-storage-key="tab8_hit_die_current">00</span>
+                                    <span class="stat-value" style="font-weight:100; opacity: 0.5;">/</span>
+                                    <span class="stat-value" data-storage-key="tab8_hit_die_max"></span>
+                                </div>
                             </div>
                         </div>
                         <div class="cs-panel stat-panel-row">

--- a/js/appManager.js
+++ b/js/appManager.js
@@ -3,6 +3,7 @@ import { categoryTags, blockTypeConfig } from './tagConfig.js';
 import { blockTemplate } from './blockTemplate.js';
 import { overlayHandler, initUsesField } from './overlayHandler.js';
 import { applyInlineDiceRolls } from './diceRoller.js';
+import { filterManager } from './filterManager.js';
 import { blockActionsHandler } from './blockActionsHandler.js';
 
 const normalizeTag = tag => tag.charAt(0).toUpperCase() + tag.slice(1).toLowerCase();
@@ -678,7 +679,7 @@ export const appManager = (() => {
   const qrState = {};
 
   const getQrState = (charTab) => {
-    if (!qrState[charTab]) qrState[charTab] = { query: '', activeTags: new Set(), expandedIds: new Set() };
+    if (!qrState[charTab]) qrState[charTab] = { query: '', expandedIds: new Set() };
     return qrState[charTab];
   };
 
@@ -1010,9 +1011,17 @@ resultsSection.innerHTML = `
       );
     }
 
-    if (state.activeTags.size > 0) {
+    const andTags = filterManager.getAndTags(charTab);
+    const orTags  = filterManager.getOrTags(charTab);
+
+    if (andTags.length > 0) {
       filtered = filtered.filter(b =>
-        [...state.activeTags].some(t => b.tags.includes(t))
+        andTags.every(t => b.tags.some(bt => normalizeTag(bt) === normalizeTag(t)))
+      );
+    }
+    if (orTags.length > 0) {
+      filtered = filtered.filter(b =>
+        orTags.some(t => b.tags.some(bt => normalizeTag(bt) === normalizeTag(t)))
       );
     }
 
@@ -1035,8 +1044,9 @@ resultsSection.innerHTML = `
       el.innerHTML = buildQrBlockHTML(block, expanded);
       blocksDiv.appendChild(el);
     });
+    applyInlineDiceRolls(blocksDiv, charTab);
+    filterManager.applySelectionClasses(charTab);
     initScrollFades('.qr-blocks-scroll', '--qr-fade-top-opacity', '--qr-fade-bottom-opacity', '_qrScrollFadeHandler');
-    document.dispatchEvent(new CustomEvent('blocksRerendered', { detail: { tab: charTab } }));
   };
 
   const wireQrEvents = (section, charTab, tabSuffix) => {
@@ -1052,42 +1062,9 @@ resultsSection.innerHTML = `
       ()      => { state.query = '';    refilterQr(charTab); }
     );
 
-    // Filter pill toggles
-    section.querySelectorAll('[data-qr-filter-tag]').forEach(pill => {
-      pill.addEventListener('click', e => {
-        e.stopPropagation();
-        const tag = pill.dataset.qrFilterTag;
-        if (state.activeTags.has(tag)) {
-          state.activeTags.delete(tag);
-          pill.classList.remove('selected');
-        } else {
-          state.activeTags.add(tag);
-          pill.classList.add('selected');
-        }
-        refilterQr(charTab);
-      });
-    });
-
-    // Delegated listener on blocks area — handles both tag clicks and expand/collapse
+    // Delegated listener on blocks area — expand/collapse only; tag clicks handled by filterManager
     blocksDiv?.addEventListener('click', e => {
-      // Tag inside a block — activate the matching filter pill
-      const tagBtn = e.target.closest('.tag-button[data-tag]');
-      if (tagBtn) {
-        e.stopPropagation();
-        const tag  = tagBtn.dataset.tag;
-        const pill = section.querySelector(`[data-qr-filter-tag="${tag}"]`);
-        if (pill) {
-          if (state.activeTags.has(tag)) {
-            state.activeTags.delete(tag);
-            pill.classList.remove('selected');
-          } else {
-            state.activeTags.add(tag);
-            pill.classList.add('selected');
-          }
-          refilterQr(charTab);
-        }
-        return;
-      }
+      if (e.target.closest('.tag-button[data-tag]')) return;
 
       // Expand / collapse block on header / empty space click
       const blockEl = e.target.closest('.block[data-qr-id]');
@@ -1112,6 +1089,10 @@ resultsSection.innerHTML = `
         blockEl.classList.replace('condensed', 'expanded');
       }
       blockEl.innerHTML = buildQrBlockHTML(block, !isExpanded);
+      if (!isExpanded) {
+          applyInlineDiceRolls(blockEl, charTab);
+          filterManager.applySelectionClasses(charTab);
+      }
       document.dispatchEvent(new CustomEvent('blocksRerendered', { detail: { tab: charTab } }));
     });
 
@@ -1147,14 +1128,17 @@ resultsSection.innerHTML = `
 
     const state = getQrState(charTab);
 
+  const andTags = filterManager.getAndTags(charTab);
+    const orTags  = filterManager.getOrTags(charTab);
+
     const actionPillsHTML = QR_ACTION_TAGS.map(tag =>
-      `<button class="tag-button tag-actionType${state.activeTags.has(tag) ? ' selected' : ''}" data-qr-filter-tag="${tag}">${tag}</button>`
+      `<button class="tag-button tag-actionType${andTags.includes(tag) ? ' selected' : orTags.includes(tag) ? ' selected-or' : ''}" data-tag="${tag}">${tag}</button>`
     ).join('');
 
     const abilityPillsHTML = QR_ABILITY_TAGS.map(tag =>
-      `<button class="tag-button tag-abilityType${state.activeTags.has(tag) ? ' selected' : ''}" data-qr-filter-tag="${tag}">${tag}</button>`
+      `<button class="tag-button tag-abilityType${andTags.includes(tag) ? ' selected' : orTags.includes(tag) ? ' selected-or' : ''}" data-tag="${tag}">${tag}</button>`
     ).join('');
-
+    
     section.innerHTML = `
       <div class="qr-filter-row">
         <div class="search-container" style="width:160px;flex-shrink:0;">

--- a/js/diceRoller.js
+++ b/js/diceRoller.js
@@ -510,7 +510,7 @@ document.addEventListener('keydown', (e) => {
 
 // ── Inline dice roll pattern & applier ───────────────────────────────────────
 
-const STAT_NAMES = 'STR|DEX|CON|INT|WIS|CHA|PROF|INIT';
+const STAT_NAMES = 'STR|DEX|CON|INT|WIS|CHA|PROF|PB|INIT';
 
 const DICE_PATTERN = new RegExp(
     `(\\d+)d(\\d+)((?:\\s*[+\\-]\\s*(?:\\d+|${STAT_NAMES}))*)`,
@@ -539,6 +539,7 @@ function resolveStatValue(statName, tabPrefix) {
         WIS:  `${tabPrefix}_wis_bonus`,
         CHA:  `${tabPrefix}_cha_bonus`,
         PROF: 'tab4_prof',
+        PB:   'tab4_prof',
         INIT: 'tab4_initiative',
     };
     const key = statMap[statName.toUpperCase()];
@@ -547,7 +548,7 @@ function resolveStatValue(statName, tabPrefix) {
 
 function parseModifierString(modStr, tabPrefix) {
     if (!modStr) return { total: 0, display: '' };
-    const termRe = /([+\-])\s*(\d+|STR|DEX|CON|INT|WIS|CHA|PROF|INIT)/gi;
+    const termRe = /([+\-])\s*(\d+|STR|DEX|CON|INT|WIS|CHA|PROF|PB|INIT)/gi;
     let total = 0, m;
     while ((m = termRe.exec(modStr)) !== null) {
         const sign = m[1] === '+' ? 1 : -1;

--- a/js/filterManager.js
+++ b/js/filterManager.js
@@ -74,7 +74,7 @@ export const filterManager = (() => {
         applyTo(`#dynamic_tags_section_${tabNumber} .tag-button`);
         // Rendered block tags
         applyTo(`#results_section_${tabNumber} .tag-button`);
-
+        
         // Accordion chips (collapsed groups)
         document.getElementById(`dynamic_tags_section_${tabNumber}`)
             ?.querySelectorAll('.tag-accordion-group:not(.open)').forEach(group => {
@@ -169,8 +169,7 @@ export const filterManager = (() => {
             if (
                 !target.classList.contains('tag-button') ||
                 target.closest('.add-block-overlay') ||
-                target.closest('.edit-block-overlay') ||
-                target.closest('.character-sheet-results')
+                target.closest('.edit-block-overlay')
             ) return;
 
             const activeTab = document.querySelector('.tab-button.active')?.dataset.tab || 'tab4';
@@ -280,6 +279,7 @@ export const filterManager = (() => {
         clearSelectedTags,
         applyFilters,
         applyFiltersAfterSave,
+        applySelectionClasses: _applySelectionClasses,
         handleTagClick,
         handleOverlayTagClick,
         filterBlocksBySelectedTags,

--- a/js/main.js
+++ b/js/main.js
@@ -7,6 +7,7 @@ import { categoryTags, blockTypeConfig } from './tagConfig.js';
 import { stripHTML } from './appManager.js';
 import { initScrollFades, setupSearchInput, initDragToScroll } from './appManager.js';
 import { initDiceRoller } from './diceRoller.js';
+import { evaluateStatExpression } from './uiHandlers.js';
 import { initLayoutMode, activateCharTab } from './layoutMode.js';
 export function repositionAllSliders() {
     requestAnimationFrame(() => {
@@ -556,13 +557,18 @@ document.addEventListener("DOMContentLoaded", () => {
 // 📌 Make character sheet editable fields more user friendly
 document.querySelectorAll("#tab4 .editable, #tab8 .editable").forEach(field => {
     field.addEventListener("focus", function () {
+        if (this.classList.contains('stat-subvalue') && this.dataset.rawExpression !== undefined) {
+            this.textContent = this.dataset.rawExpression;
+            this.dataset.initialValue = this.dataset.rawExpression;
+        } else {
+            this.dataset.initialValue = this.textContent;
+        }
         const range = document.createRange();
         range.selectNodeContents(this);
         const selection = window.getSelection();
         selection.removeAllRanges();
         selection.addRange(range);
         this.style.opacity = "1";
-        this.dataset.initialValue = this.textContent;
     });
 
     field.addEventListener("keydown", function (e) {
@@ -966,12 +972,20 @@ window.onload = async () => {
             const key = el.getAttribute('data-storage-key');
             if (key) {
                 const defaultValue = el.closest('.descriptor-grid') ? "XX" : "00";
+                const isSubvalue = el.classList.contains('stat-subvalue');
                 let savedValue = localStorage.getItem(key);
                 if (savedValue !== null && savedValue !== "") {
-                    el.textContent = savedValue;
+                    if (isSubvalue) {
+                        el.dataset.rawExpression = savedValue;
+                        const evaluated = evaluateStatExpression(savedValue);
+                        el.textContent = evaluated !== null ? String(evaluated) : savedValue;
+                    } else {
+                        el.textContent = savedValue;
+                    }
                     el.style.opacity = (savedValue === defaultValue) ? "0.5" : "1";
                 } else {
                     el.textContent = defaultValue;
+                    if (isSubvalue) el.dataset.rawExpression = defaultValue;
                     el.style.opacity = "0.5";
                     localStorage.setItem(key, defaultValue);
                 }
@@ -981,7 +995,13 @@ window.onload = async () => {
                         newValue = defaultValue;
                         el.textContent = newValue;
                         el.style.opacity = "0.5";
+                        if (isSubvalue) el.dataset.rawExpression = newValue;
                     } else {
+                        if (isSubvalue) {
+                            el.dataset.rawExpression = newValue;
+                            const evaluated = evaluateStatExpression(newValue);
+                            if (evaluated !== null) el.textContent = String(evaluated);
+                        }
                         el.style.opacity = (newValue === defaultValue) ? "0.5" : "1";
                     }
                     localStorage.setItem(key, newValue);

--- a/js/uiHandlers.js
+++ b/js/uiHandlers.js
@@ -6,6 +6,24 @@
 /* ==================================================================*/
 
 // Determine if a save or skill toggle is proficient
+
+export function evaluateStatExpression(expr) {
+    const trimmed = expr.trim();
+    if (!/[+\-]/.test(trimmed)) return null;
+    if (!/^[+\-]?[\d\.]+(\s*[+\-]\s*[\d\.]+)*$/.test(trimmed)) return null;
+    const matches = trimmed.match(/[+\-]?\s*[\d\.]+/g);
+    if (!matches) return null;
+    const result = matches.reduce((sum, part) => sum + parseFloat(part.replace(/\s/g, '')), 0);
+    if (isNaN(result)) return null;
+    return Number.isInteger(result) ? result : parseFloat(result.toFixed(2));
+}
+
+function syncHitDieMax(tabPrefix) {
+    const level = localStorage.getItem(`${tabPrefix}_level`) || '';
+    const el = document.querySelector(`[data-storage-key="${tabPrefix}_hit_die_max"]`);
+    if (el) el.textContent = level;
+}
+
 function isProficient(toggleKey) {
     const toggle = document.querySelector(`[data-storage-key="${toggleKey}"]`);
     return toggle && toggle.classList.contains("filled");
@@ -38,7 +56,8 @@ function calculateAbilityBonus(scoreKey, bonusKey) {
         if (el) el.textContent = "00";
         return;
     }
-    const score = parseInt(raw, 10);
+    const evaluated = evaluateStatExpression(raw);
+    const score = evaluated !== null ? evaluated : parseInt(raw, 10);
     const mod = Math.floor((score - 10) / 2);
     localStorage.setItem(bonusKey, mod);
     if (el) el.textContent = (mod >= 0 ? "+" : "") + mod;
@@ -161,6 +180,8 @@ function initSaveSkillRollHandlers() {
 // Initial calculation after all load handlers
 window.addEventListener("load", () => {
     setTimeout(() => {
+        syncHitDieMax('tab4');
+        syncHitDieMax('tab8');
         updateTab4AbilityBonuses();
         updateTab8AbilityBonuses();
         updateTab4Saves();
@@ -177,6 +198,8 @@ document.addEventListener("input", (e) => {
     const key = e.target.getAttribute("data-storage-key");
     if (!key) return;
     localStorage.setItem(key, e.target.textContent);
+    if (key === 'tab4_level') syncHitDieMax('tab4');
+    else if (key === 'tab8_level') syncHitDieMax('tab8');
     if (key.endsWith("_score")) {
         if (key.startsWith("tab4_")) updateTab4AbilityBonuses();
         else if (key.startsWith("tab8_")) updateTab8AbilityBonuses();


### PR DESCRIPTION
Fixed tags inside block in character sheet tabs not showing selected states and those blocks now shoing inline dice rolls.
Made tags insideall blocks smaller.
Added an editing state to editable blocks in character sheet stats.
Made hit die equal to level inside characte sheet and split into 2 fields.
Added "PB" as a recognised phrase for in-line dice rolls.
Stat- subvalues now recognise + and - sums.
Refined layout of blocks with a gap: value.