### PR TITLE
3.4.2

### DIFF
--- a/css/base-layout.css
+++ b/css/base-layout.css
@@ -1020,9 +1020,6 @@ a:hover {
 }
 
 .session-viewer-body[contenteditable="true"] {
-    outline: none;
-    border-color: var(--gray-500);
-    background-color: var(--gray-400);
 }
 
 .session-viewer-tags {

--- a/css/base-layout.css
+++ b/css/base-layout.css
@@ -680,6 +680,31 @@ body:not(.landscape-mode) #char-sheet-panel .tab-content {
     row-gap: 8px;
 }
 
+.block.condensed .block-tags-condensed .tag-button {
+    display: none;
+}
+
+.block.condensed .block-tags-condensed .tag-button.selected,
+.block.condensed .block-tags-condensed .tag-button.selected-or {
+    display: inline-flex;
+    font-size: 0.7em;
+    padding: 1px 6px;
+}
+
+.block-tags-condensed {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    flex: 1;
+    margin: 0;
+    padding: 0;
+    gap: 4px;
+    min-width: 0;
+    overflow: hidden;
+    mask-image: linear-gradient(to right, black 70%, transparent 100%);
+    -webkit-mask-image: linear-gradient(to right, black 70%, transparent 100%);
+}
+
 .block-body {
     display: flex;
     flex-direction: column;

--- a/js/appManager.js
+++ b/js/appManager.js
@@ -1043,18 +1043,36 @@ resultsSection.innerHTML = `
       );
     }
 
-    const andTags = filterManager.getAndTags(tab);
-    const orTags  = filterManager.getOrTags(tab);
+    const andTags = filterManager.getAndTags(charTab);
+    const orTags  = filterManager.getOrTags(charTab);
 
-    if (andTags.length > 0) {
+    const tab9Types      = blockTypeConfig['tab9']?.types || [];
+    const andBlockTypes  = andTags.filter(t => tab9Types.includes(t));
+    const orBlockTypes   = orTags.filter(t => tab9Types.includes(t));
+    const regularAndTags = andTags.filter(t => !tab9Types.includes(t));
+    const regularOrTags  = orTags.filter(t => !tab9Types.includes(t));
+
+    if (regularAndTags.length > 0) {
       filtered = filtered.filter(b =>
-        andTags.every(t => b.tags.some(bt => normalizeTag(bt) === normalizeTag(t)))
+        regularAndTags.every(t => b.tags.some(bt => normalizeTag(bt) === normalizeTag(t)))
       );
     }
-    if (orTags.length > 0) {
+    if (regularOrTags.length > 0) {
       filtered = filtered.filter(b =>
-        orTags.some(t => b.tags.some(bt => normalizeTag(bt) === normalizeTag(t)))
+        regularOrTags.some(t => b.tags.some(bt => normalizeTag(bt) === normalizeTag(t)))
       );
+    }
+    if (andBlockTypes.length > 0) {
+      filtered = filtered.filter(b => {
+        const types = Array.isArray(b.blockType) ? b.blockType : (b.blockType ? [b.blockType] : []);
+        return andBlockTypes.every(t => types.includes(t));
+      });
+    }
+    if (orBlockTypes.length > 0) {
+      filtered = filtered.filter(b => {
+        const types = Array.isArray(b.blockType) ? b.blockType : (b.blockType ? [b.blockType] : []);
+        return orBlockTypes.some(t => types.includes(t));
+      });
     }
 
     blocksDiv.innerHTML = '';

--- a/js/appManager.js
+++ b/js/appManager.js
@@ -1,7 +1,7 @@
 // appManager.js
 import { categoryTags, blockTypeConfig } from './tagConfig.js';
 import { blockTemplate } from './blockTemplate.js';
-import { overlayHandler, initUsesField } from './overlayHandler.js';
+import { overlayHandler, initUsesField, initToolbarForEditor } from './overlayHandler.js';
 import { applyInlineDiceRolls } from './diceRoller.js';
 import { filterManager } from './filterManager.js';
 import { blockActionsHandler } from './blockActionsHandler.js';
@@ -429,14 +429,18 @@ export const appManager = (() => {
       const titleEl = viewer.querySelector('.session-viewer-title');
       const bodyEl  = viewer.querySelector('#session_viewer_body');
       let snapshot = null;
+      let enforceList = null;
+      let viewerToolbarTeardown = null;
 
       const exitSave = () => {
           sessionViewerEditMode   = false;
           editBtn.classList.remove('active');
+          if (viewerToolbarTeardown) { viewerToolbarTeardown(); viewerToolbarTeardown = null; }
           titleEl.contentEditable = 'false';
           bodyEl.contentEditable  = 'false';
           titleEl.removeEventListener('keydown', keydownHandler);
           bodyEl.removeEventListener('keydown', keydownHandler);
+          if (enforceList) bodyEl.removeEventListener('input', enforceList);
 
           const newTitle     = titleEl.textContent.trim() || block.title;
           const newText      = bodyEl.innerHTML.trim();
@@ -477,6 +481,8 @@ export const appManager = (() => {
           bodyEl.contentEditable  = 'false';
           titleEl.removeEventListener('keydown', keydownHandler);
           bodyEl.removeEventListener('keydown', keydownHandler);
+          if (enforceList) bodyEl.removeEventListener('input', enforceList);
+          if (viewerToolbarTeardown) { viewerToolbarTeardown(); viewerToolbarTeardown = null; }
 
           if (snapshot) {
               titleEl.textContent = snapshot.title;
@@ -494,14 +500,22 @@ export const appManager = (() => {
           }
       };
 
+      let lastEscapeTime = 0;
       const keydownHandler = (e) => {
           if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
               e.preventDefault();
+              e.stopPropagation();
               exitSave();
           } else if (e.key === 'Escape') {
               e.preventDefault();
               e.stopPropagation();
-              exitDiscard();
+              const now = Date.now();
+              if (now - lastEscapeTime < 400) {
+                  lastEscapeTime = 0;
+                  exitDiscard();
+              } else {
+                  lastEscapeTime = now;
+              }
           }
       };
 
@@ -524,8 +538,26 @@ export const appManager = (() => {
 
               titleEl.contentEditable = 'true';
               bodyEl.contentEditable  = 'true';
+
               titleEl.addEventListener('keydown', keydownHandler);
               bodyEl.addEventListener('keydown', keydownHandler);
+
+              enforceList = () => {
+                  if (!bodyEl.querySelector('ul, ol')) {
+                      bodyEl.innerHTML = '<ul><li></li></ul>';
+                      const li = bodyEl.querySelector('li');
+                      if (li) {
+                          const range = document.createRange();
+                          const sel   = window.getSelection();
+                          range.selectNodeContents(li);
+                          range.collapse(false);
+                          sel.removeAllRanges();
+                          sel.addRange(range);
+                      }
+                  }
+              };
+              bodyEl.addEventListener('input', enforceList);
+              viewerToolbarTeardown = initToolbarForEditor(bodyEl);
 
               viewer.querySelector('.session-viewer-delete-btn')?.classList.add('visible');
 
@@ -576,7 +608,7 @@ export const appManager = (() => {
               const newBlock = {
                   id:         crypto.randomUUID(),
                   title:      generateNextSessionTitle(),
-                  text:       '',
+                  text:       '<ul><li><br></li></ul>',
                   tags:       [],
                   uses:       [],
                   properties: [],

--- a/js/appManager.js
+++ b/js/appManager.js
@@ -1043,8 +1043,8 @@ resultsSection.innerHTML = `
       );
     }
 
-    const andTags = filterManager.getAndTags(charTab);
-    const orTags  = filterManager.getOrTags(charTab);
+    const andTags = filterManager.getAndTags(tab);
+    const orTags  = filterManager.getOrTags(tab);
 
     if (andTags.length > 0) {
       filtered = filtered.filter(b =>

--- a/js/blockTemplate.js
+++ b/js/blockTemplate.js
@@ -116,10 +116,18 @@ export const blockTemplate = (block, tab = "tab4") => {
                 `<span class="circle ${state ? 'unfilled' : ''}" onclick="toggleBlockUse('${block.id}', ${idx}, event, this)"></span>`
               ).join("")
             : "";
+        const condensedTagsHTML = hasAnyTags ? `
+            <div class="block-tags block-tags-condensed">
+                ${blockTypeHTML}
+                ${predefinedTagsHTML}
+                ${userTagsHTML}
+            </div>
+        ` : "";
         content = `
             <div class="block-header">
                 <div class="block-title"><h4>${block.title}</h4></div>
                 ${ usesHTML ? `<div class="block-uses">${usesHTML}</div>` : "" }
+                ${condensedTagsHTML}
                 ${actionMenuHTML}
             </div>
         `;

--- a/js/overlayHandler.js
+++ b/js/overlayHandler.js
@@ -218,6 +218,8 @@ export const handleSaveBlock = () => {
     });
 };
 
+let initToolbarForEditor;
+
 export const overlayHandler = (() => {
     const selectedOverlayTags = Object.keys(categoryTags).reduce((acc, category) => {
         acc[category] = [];
@@ -478,18 +480,7 @@ export const overlayHandler = (() => {
 /* ========================== TEXT TOOLBAR ==========================*/
 /* ==================================================================*/
 
-function addFormatToolbar() {
-    const configs = [
-      { formSel: '.add-block-form', textareaId: 'block_text_overlay' },
-      { formSel: '.edit-block-form', textareaId: 'block_text_edit_overlay' }
-    ];
-  
-    configs.forEach(({ formSel, textareaId }) => {
-      const form = document.querySelector(formSel);
-      if (!form) return;
-      const editor = form.querySelector(`#${textareaId}`);
-      if (!editor) return;
-  
+initToolbarForEditor = function(editor) {
       const toolbar = document.createElement('div');
       toolbar.className = 'text-toolbar';
       toolbar.innerHTML = `
@@ -867,6 +858,25 @@ function addFormatToolbar() {
         document.execCommand('insertHTML', false, cleaned);
         updateToolbarState();
       });
+
+    return function teardown() {
+        if (wrapper.parentNode) {
+            wrapper.parentNode.replaceChild(editor, wrapper);
+        }
+    };
+}
+
+function addFormatToolbar() {
+    const configs = [
+      { formSel: '.add-block-form', textareaId: 'block_text_overlay' },
+      { formSel: '.edit-block-form', textareaId: 'block_text_edit_overlay' }
+    ];
+    configs.forEach(({ formSel, textareaId }) => {
+      const form = document.querySelector(formSel);
+      if (!form) return;
+      const editor = form.querySelector(`#${textareaId}`);
+      if (!editor) return;
+      initToolbarForEditor(editor);
     });
 }
     
@@ -904,4 +914,4 @@ function initCEPlaceholder(id) {
     };
 })();
 
-export { initUsesField };
+export { initUsesField, initToolbarForEditor };


### PR DESCRIPTION
Selected tags now appear in condensed blocks in results sections

Reinstated the edit toolbar for editing in the session log

Saving session log edits with 'ctrl + enter' no longer also rolls dice

To leave editing session log without saving edits now requries double tapping escape instead of a sinlge tap to avoid accidents

New session log block attomatically start with bulltpoints

Block Type Tags now filter correctly in the Quick reference results section